### PR TITLE
Handle splash screen state and menu rendering

### DIFF
--- a/GhostRadar_ESP32/src/main.cpp
+++ b/GhostRadar_ESP32/src/main.cpp
@@ -22,32 +22,35 @@ void setup() {
 
 void loop() {
   // put your main code here, to run repeatedly:
+  static bool isBootScreen = true;
+  static bool isMenuActive = false;
+
   uint16_t x = 0, y = 0;
-
-  bool isBootScreen = true;
-  bool isMenuActive = false;
-
   bool pressed = tft.getTouch(&x, &y);
 
-  if (!pressed && isBootScreen) {
+  if (isBootScreen) {
+    // Show the splash screen until the user taps the display once.
     drawSplashScreen();
-    pressed = tft.getTouch(&x, &y);
+    if (pressed) {
+      isBootScreen = false;
+      tft.fillScreen(TFT_BLACK);
+    }
+    return;
   }
-  else if (pressed && !isMenuActive) {
+
+  if (pressed && !isMenuActive) {
     isMenuActive = true;
     tft.fillScreen(TFT_BLACK);
-    
-    while (isMenuActive) {
-      drawMenuScreen();
-      delay(10);
-
-      tft.setTextSize(2);
-      tft.drawNumber(getTemperature(), 60, 170);
-      tft.drawNumber(getHumidity(), 165, 170);
-      tft.drawNumber(x, 165, 140);
-      tft.drawNumber(y, 60, 140);
-
-    }
   }
-  
+
+  if (isMenuActive) {
+    drawMenuScreen();
+    delay(10);
+
+    tft.setTextSize(2);
+    tft.drawNumber(getTemperature(), 60, 170);
+    tft.drawNumber(getHumidity(), 165, 170);
+    tft.drawNumber(x, 165, 140);
+    tft.drawNumber(y, 60, 140);
   }
+}


### PR DESCRIPTION
## Summary
- preserve splash/menu state across loop iterations instead of reinitializing every pass
- replace blocking menu loop with per-iteration rendering to keep touch and sensor updates responsive
- clear the display once when exiting the splash screen before showing the menu

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69222863972c832fbb5c5ebc8e2b13bb)